### PR TITLE
Feature: Startup retry, health/metrics endpoints, notifications, retry logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,19 @@ IO_THRESHOLD=80
 DRY_RUN=true
 LOG_LEVEL=INFO
 TZ=UTC
+
+# Retry behavior (optional)
+MAX_RETRIES=3
+RETRY_BACKOFF=2
+RETRY_BASE_DELAY=1
+
+# Startup retry (optional)
+STARTUP_RETRIES=10
+STARTUP_RETRY_DELAY=30
+
+# Health check / metrics (optional, set to 0 to disable)
+HEALTH_PORT=8095
+
+# Notifications (optional)
+DISCORD_WEBHOOK_URL=
+WEBHOOK_URL=

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,9 @@ COPY guardian.py .
 RUN adduser -D -u 1000 guardian
 USER guardian
 
+EXPOSE 8095
+
+HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8095/health')" || exit 1
+
 CMD ["python", "-u", "guardian.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,14 +17,24 @@ services:
       # SABNZBD_API_KEY: "your-sab-key"
       # Disk I/O (optional)
       # DISK_DEVICES: "sda,nvme0n1"
+      # Notifications (optional)
+      # DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/..."
+      # WEBHOOK_URL: "https://your-webhook-endpoint/..."
       # Behavior
       POLL_INTERVAL: "30"
       STUCK_SCAN_TIMEOUT: "7200"
       DRY_RUN: "true"
       TZ: "America/New_York"
+    ports:
+      - "8095:8095"
     # volumes:
     #   - /proc/diskstats:/host/proc/diskstats:ro
     mem_limit: 64m
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8095/health')"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary

- Fix crash: Container exited immediately on Emby unreachable. Now retries STARTUP_RETRIES times.
- Issue #1: Discord/webhook notifications for guardian events (NotificationClient class)
- Issue #2: HTTP health check endpoint (GET /health returns JSON, 200/503)
- Issue #3: Exponential backoff retry for all API calls (retry_request wrapper)
- Issue #4: Prometheus metrics endpoint (GET /metrics, 11 guardian_ metrics)

All features use graceful degradation, no new dependencies, backward compatible.

Closes #1, closes #2, closes #3, closes #4

Generated with Claude Code