### PR TITLE
Add 'Scan for episode intros' to default PAUSABLE_TASKS

### DIFF
--- a/guardian.py
+++ b/guardian.py
@@ -82,7 +82,8 @@ LOG_LEVEL = env("LOG_LEVEL", "INFO").upper()
 PAUSABLE_TASKS = [t.strip() for t in env(
     "PAUSABLE_TASKS",
     "Scan media library,Refresh Guide,Download subtitles,"
-    "Video preview thumbnail extraction,Scan Metadata Folder"
+    "Video preview thumbnail extraction,Scan Metadata Folder,"
+    "Scan for episode intros"
 ).split(",") if t.strip()]
 
 # Retry behavior


### PR DESCRIPTION
## Summary

- Adds `Scan for episode intros` to the default `PAUSABLE_TASKS` list
- Fixes the issue where Emby would scan for intro timestamps during active playback, causing unnecessary I/O
- Users no longer need to manually set `PAUSABLE_TASKS` env var to include this task

Closes #7

🤖 *This PR was created by Claude AI assisting the maintainer.*